### PR TITLE
Add support for precompiled assets manifest in Sprockets >= 3.0

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -21,6 +21,7 @@ module Teaspoon
       @name = (@options[:suite] || :default).to_s
       @config = suite_configuration
       @env = Rails.application.assets
+      @manifest = Rails.application.assets_manifest
     end
 
     def spec_files
@@ -42,6 +43,8 @@ module Teaspoon
 
     protected
 
+    class ManifestAsset < Struct.new(:logical_path, :filename, :metadata); end
+
     def specs
       files = specs_from_file
       return files unless files.empty?
@@ -50,7 +53,14 @@ module Teaspoon
 
     def asset_tree(sources)
       sources.flat_map do |source|
-        asset = @env.find_asset(source, accept: "application/javascript", pipeline: :debug)
+        asset = if @env
+          @env.find_asset(source, accept: "application/javascript", pipeline: :debug)
+        elsif @manifest
+          matching_manifest_files = @manifest.files.select { |_, attribs| attribs['logical_path'].include?(source) }
+          matching_manifest_files.map do |filename, attribs|
+            ManifestAsset.new(attribs['logical_path'], filename, { :included => [] })
+          end
+        end
 
         if asset && asset.respond_to?(:logical_path)
           asset_and_dependencies(asset).map { |a| asset_url(a) }


### PR DESCRIPTION
Sprockets 3.0 has changed the way assets can be accessed if the fallback
asset pipeline is disabled (Rails config option `config.asets.compile`
is set to false).

In such case, scenario, extracting asset information based on
Sprockets environment doesn't work, since `Rails.application.assets`
returns nil.

Fortunately, similar information about assets can be obtained from asset
manifest, accessible from `Rails.application.assets_manifest`.

This change makes teaspoon fall back to using the assets manifest if
regular asset environment is not available. It seems to work for all the
use cases that I tested.